### PR TITLE
Better grpc description

### DIFF
--- a/docs/guides/coding-guide.md
+++ b/docs/guides/coding-guide.md
@@ -64,7 +64,7 @@ Models should be well thought through. _More is less_ - rather keep the size of 
 Currently the defacto standard for Open APIs. Lightweight and human-readable.
 
 * **gRPC with protobuf**
-Offers better performance and easier code generation, but not human readable in transit.
+Offers better performance and easier code generation, but a bit harder to set up and use, and not human readable in transit.
 
 * ** **
 

--- a/docs/guides/coding-guide.md
+++ b/docs/guides/coding-guide.md
@@ -63,8 +63,8 @@ Models should be well thought through. _More is less_ - rather keep the size of 
 * **RESTful HTTP-based APIs using JSON**
 Currently the defacto standard for Open APIs. Lightweight and human-readable.
 
-* **gRPC**
-A newer binary format which offers better performance, but not human readable. 
+* **gRPC with protobuf**
+Offers better performance and easier code generation, but not human readable in transit.
 
 * ** **
 


### PR DESCRIPTION
I barely know anything about grpc, but grpc is not a format, its a framework which happens to *normally* use protobuf (the binary message format), so I felt this was a bit less misleading